### PR TITLE
Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,55 @@
 ![](https://img.shields.io/badge/Microverse-blueviolet)
 
-# Project Name
-
-> One paragraph statement about the project.
-
-![screenshot](./app_screenshot.png)
-
-Additional description about the project and its features.
-
-## Built With
-
-- Major languages
-- Frameworks
-- Technologies used
-
-## Live Demo
-
-[Live Demo Link](https://livedemo.com)
+# Enumerable Methods
 
 
-## Getting Started
 
-**This is an example of how you may give instructions on setting up your project locally.**
-**Modify this file to match your project, remove sections that don't apply. For example: delete the testing section if the currect project doesn't require testing.**
+## Built with
 
-
-To get a local copy up and running follow these simple example steps.
+- Ruby
 
 ### Prerequisites
 
+- Web browser
+- IDE
+- Ruby
+
 ### Setup
+
+- Download/Clone the repository files and navigate to root folder 
+- Run *ruby main.rb* from command line
+- Watch results
+- You can modify the source code to sort any array of strings or integers
 
 ### Install
 
-### Usage
-
-### Run tests
+- Follow [these](https://www.theodinproject.com/paths/full-stack-ruby-on-rails/courses/ruby-programming/lessons/installing-ruby-ruby-programming) steps in order to install ruby 
 
 ### Deployment
 
+- You can deploy this project by cloning it then:
 
+- Go to the repository's settings.
+- Navigate to the GitHub Pages section.
+- Select the appropriate branch.
+
+### Live version
+
+[Live version here]()
 
 ## Authors
 
-👤 **Author1**
+**👤 Kenny Ortega**
 
-- GitHub: [@githubhandle](https://github.com/githubhandle)
-- Twitter: [@twitterhandle](https://twitter.com/twitterhandle)
-- LinkedIn: [LinkedIn](https://linkedin.com/in/linkedinhandle)
+- GitHub: [kensayo](https://github.com/kensayo)
+- Twitter: [@kensayo](https://twitter.com/kensayo)
+- LinkedIn: [LinkedIn](https://www.linkedin.com/in/kenny-ortega-3580aa33/)
 
-👤 **Author2**
+**👤 Mario Alberto Rodriguez Cota**
 
-- GitHub: [@githubhandle](https://github.com/githubhandle)
-- Twitter: [@twitterhandle](https://twitter.com/twitterhandle)
-- LinkedIn: [LinkedIn](https://linkedin.com/in/linkedinhandle)
+- GitHub: [@mariordgez](https://github.com/mariordgez)
+- Twitter: [@MarioRo75396624](https://twitter.com/MarioRo75396624)
+- LinkedIn: [LinkedIn](www.linkedin.com/in/mario-alberto-rodriguez-cota-a2860a205)
 
 ## 🤝 Contributing
 
@@ -67,10 +63,5 @@ Give a ⭐️ if you like this project!
 
 ## Acknowledgments
 
-- Hat tip to anyone whose code was used
-- Inspiration
-- etc
-
-## 📝 License
-
-This project is [MIT](./MIT.md) licensed.
+- [Microverse](https://www.microverse.org/)
+- [The Odin Project](https://www.theodinproject.com/paths/full-stack-ruby-on-rails/courses/ruby-programming/lessons/bubble-sort)

--- a/main.rb
+++ b/main.rb
@@ -33,28 +33,20 @@ module Enumerable
   end
 
   # my_all? method
-  def my_all? (args=nil)
+  def my_all?(args = nil)
     case args
     when Regexp
-      to_a.my_each do |var|
-        return false unless args.match(var)
-      end
-    when Class
-      to_a.my_each do |var|
-        return false unless var.class.superclass == args || var.class == args
-      end
-    else  
-    unless block_given?
-      to_a.my_each do |var|
-        return false unless var
-      else return true
-      end
-      
-    end  
+      to_a.my_each { |var| return false unless args.match(var) }
 
-    to_a.size.times do |i|
-      return false unless yield to_a[i]
-    end
+    when Class
+      to_a.my_each { |var| return false unless var.class.superclass == args || var.instance_of?(args) }
+    else
+      unless block_given?
+        to_a.my_each { |var| return false unless var }
+        return true
+      end
+
+      to_a.size.times { |i| return false unless yield to_a[i] }
     end
     true
   end
@@ -63,77 +55,69 @@ module Enumerable
   def my_any?(args = nil)
     case args
     when Regexp
-      to_a.my_each do |var|
-        return true if args.match(var)
-      end
+      to_a.my_each { |var| return true if args.match(var) }
     when Class
-      to_a.my_each do |var|
-        return true if var.instance_of?(args)
-      end
+      to_a.my_each { |var| return true if var.class.superclass == args || var.instance_of?(args) }
     else
-      return true unless block_given?
-
-      to_a.my_each do |var|
-        return true if yield var
+      unless block_given?
+        to_a.my_each { |var| return true if var == true }
+        return false
       end
+
+      to_a.my_each { |var| return true if yield var }
     end
     false
   end
 
   # my_none? Method
-  def my_none?(args=nil)
+  def my_none?(args = nil)
     case args
     when Regexp
       to_a.my_each do |var|
-        return false if args.match(var)
+        my_regexp(false, var)
       end
     when Class
-      to_a.my_each do |var|
-        return false if var.class==args || var.class.superclass==args
+      to_a.my_each { |var| return false if var.class.superclass == args || var.instance_of?(args) }
+    else
+      unless block_given?
+        to_a.my_each { |var| return false if var }
+        return true
       end
-    else  
-    return false unless block_given?
 
-    my_each do |var|
-      return false if yield var
+      my_each { |var| return false if yield var }
     end
-  end
     true
   end
 
   # my_count Method
-  def my_count (num=nil)
+  def my_count(num = nil)
     return to_a.size unless block_given?
-    counter=0
+
+    counter = 0
     if num
-      my_each do 
-        |var| 
-        if var == num
-          counter+=1
-        end
+      my_each do |var|
+        counter += 1 if var == num
       end
 
     else
-    my_each do |var|
-      counter+=1 if yield var
+      my_each do |var|
+        counter += 1 if yield var
+      end
     end
-  end
     counter
   end
 
   # my_map Method
   def my_map
     return to_enum(:my_map) unless block_given?
-    mp_new=[]
-    my_each { |var| mp_new.push(yield(var))}
+
+    mp_new = []
+    my_each { |var| mp_new.push(yield(var)) }
     mp_new
   end
 
-
-p "all example"
-p %w[ant bear cat].my_all? { |word| word.length >= 3 } #=> true
-p %w[ant bear cat].my_all? { |word| word.length >= 4 } #=> false
-p %w[ant bear cat].my_all?(/a/)                        #=> false
-p [1, 2, 3].my_all?(Numeric)                       #=> true
-p [nil, true, 99].my_all?                              #=> false
+  def my_regexp(xav, var)
+    return xav if args.match(var)
+  end
+  p 'hello world'
 end

--- a/main.rb
+++ b/main.rb
@@ -1,4 +1,5 @@
 module Enumerable
+  # my_each method
   def my_each
     to_a.size.times do |i|
       yield self[i]
@@ -6,6 +7,7 @@ module Enumerable
     self
   end
 
+  # my_each_with_index
   def my_each_with_index
     to_a.size.times do |i|
       yield self[i], i
@@ -13,6 +15,7 @@ module Enumerable
     self
   end
 
+  # my_select method
   def my_select
     arr = []
     to_a.size.times do |i|

--- a/main.rb
+++ b/main.rb
@@ -1,16 +1,18 @@
 module Enumerable
   # my_each method
   def my_each
+    return to_enum(:my_each) unless block_given?    
     to_a.size.times do |i|
-      yield self[i]
+      yield to_a[i]
     end
     self
   end
 
   # my_each_with_index
   def my_each_with_index
+    return to_enum(:my_each_with_index) unless block_given?
     to_a.size.times do |i|
-      yield self[i], i
+      yield self.to_a[i], i
     end
     self
   end
@@ -25,10 +27,14 @@ module Enumerable
   end
 
   # my_all? method
-  def my_all?
-    my_each do |var|
-      false unless yield var
+  def my_all?    
+    to_a.size.times do |i|
+      if !yield self.to_a[i]
+        return false
+      end
     end
     true
   end
+
 end
+

--- a/main.rb
+++ b/main.rb
@@ -41,4 +41,20 @@ module Enumerable
     end
     true
   end
+
+  def my_any?
+    return true unless block_given?    
+    my_each do |var|
+     return true if yield var
+    end
+    false
+  end
+
+  def my_none?
+    return false unless block_given?  
+    my_each do |var|
+     return false if yield var
+    end
+    true
+  end
 end

--- a/main.rb
+++ b/main.rb
@@ -32,8 +32,3 @@ module Enumerable
     true
   end
 end
-
-
-words = %w[bacon orang apple]
-
-puts [].my_all? {|str| str.size == 5}

--- a/main.rb
+++ b/main.rb
@@ -42,37 +42,45 @@ module Enumerable
     true
   end
 
-  def my_inject(*arg)
+  def my_initemect(*arg)
 
-    if arg.empty?
-      sum = arg[0]
-      operator = :+
-    elsif arg[0].is_a? Symbol
-      operator = arg[0]
-      sum = 0
-    elsif arg[0].is_a? Integer && arg.size > 1
-      sum = arg[0]
-      operator arg[1]
-    elsif arg[0].is_a? Integer
-      sum = 0
-      operator = :+
-    end
-    
-    #if block_given? sum = ; puts var 
-      proc = Proc.new { |num| sum = sum.send operator, num }      
-    #else
-    #  puts "No hay yield"
-    #end
+    var = var.is_a?(Range) ? var.to_a : self
 
-    my_each {|var| proc.call(var) unless block_given?}
+    base = arg[0].is_a?(Integer) ? arg[0] : 0
+    operator = arg[0].is_a?(Symbol) ? arg[0] : arg[1]
+        p operator
+        p base
+    my_each {|var| base = base.send operator, var}
 
-    sum
+    base
   end
+
+  def my_inject(arg1 = nil, arg2 = nil)
+
+    if arg1.is_a?(Symbol) && !arg2
+      base = to_a[0]
+      1.upto(to_a.length - 1) { |item| base = base.send(arg1, to_a[item]) }
+    elsif arg1.is_a?(Integer) && !arg2
+      base = arg1
+      1.upto(to_a.length - 1) { |item| base = base.send(:+, to_a[item]) }
+    elsif !arg1.is_a?(Symbol) && arg2.is_a?(Symbol)
+      base = arg1
+      0.upto(to_a.length - 1) { |item| base = base.send(arg2, to_a[item]) }
+    elsif block_given? && arg1
+      base = arg1
+      to_a.my_each { |val| base = yield(base, val) }
+    elsif block_given? && !arg1
+      base = to_a[0]
+      1.upto(to_a.length - 1) { |item| base = yield(base, to_a[item]) }
+    elsif !block_given? && !arg1
+      raise LocalJumpError
+    else
+      return 'Input Error'
+    end
+    base
+  end
+
 end
 
-arr = [1,2,3,4,5,6,]
-p arr.my_inject { |sum, n| sum + n }
-
-
-#p 1.send(:method)
-#p 4.send(:+,5)
+arr = [1,2,3]
+p arr.my_inject(100)

--- a/main.rb
+++ b/main.rb
@@ -1,7 +1,8 @@
 module Enumerable
   # my_each method
   def my_each
-    return to_enum(:my_each) unless block_given?    
+    return to_enum(:my_each) unless block_given?
+
     to_a.size.times do |i|
       yield to_a[i]
     end
@@ -11,30 +12,33 @@ module Enumerable
   # my_each_with_index
   def my_each_with_index
     return to_enum(:my_each_with_index) unless block_given?
+
     to_a.size.times do |i|
-      yield self.to_a[i], i
+      yield to_a[i], i
     end
     self
   end
 
   # my_select method
   def my_select
+    return to_enum(:my_select) unless block_given?
+
     arr = []
     to_a.size.times do |i|
-      arr.push(self[i]) if yield self[i]
+      arr.push(to_a[i]) if yield to_a[i]
     end
+    return arr.to_h if is_a? Hash
+
     arr
   end
 
   # my_all? method
-  def my_all?    
+  def my_all?
+    return true unless block_given?
+
     to_a.size.times do |i|
-      if !yield self.to_a[i]
-        return false
-      end
+      return false unless yield to_a[i]
     end
     true
   end
-
 end
-

--- a/main.rb
+++ b/main.rb
@@ -46,18 +46,6 @@ module Enumerable
     true
   end
 
-  def my_initemect(*arg)
-    var = var.is_a?(Range) ? var.to_a : self
-
-    base = arg[0].is_a?(Integer) ? arg[0] : 0
-    operator = arg[0].is_a?(Symbol) ? arg[0] : arg[1]
-    p operator
-    p base
-    my_each { |var| base = base.send operator, var }
-
-    base
-  end
-
   def my_inject(arg1 = nil, arg2 = nil)
     if arg1.is_a?(Symbol) && !arg2
       base = to_a[0]

--- a/main.rb
+++ b/main.rb
@@ -32,3 +32,8 @@ module Enumerable
     true
   end
 end
+
+
+words = %w[bacon orang apple]
+
+puts [].my_all? {|str| str.size == 5}

--- a/main.rb
+++ b/main.rb
@@ -34,58 +34,51 @@ module Enumerable
 
   # my_all? method
   def my_all?(args = nil)
-    case args
-    when Regexp
-      to_a.my_each { |var| return false unless args.match(var) }
-
-    when Class
-      to_a.my_each { |var| return false unless var.class.superclass == args || var.instance_of?(args) }
-    else
-      unless block_given?
-        to_a.my_each { |var| return false unless var }
+    unless block_given?
+      if args.instance_of?(Regexp)
+        to_a.my_each { |var| return false unless args.match(var) }
         return true
+      else
+        to_a.my_each { |var| return false unless my_instance_of(args, var) }
       end
-
-      to_a.size.times { |i| return false unless yield to_a[i] }
+      to_a.my_each { |var| return false unless var }
+      return true
     end
+    to_a.size.times { |i| return false unless yield to_a[i] }
+
     true
   end
 
   # my_any? Method
   def my_any?(args = nil)
-    case args
-    when Regexp
-      to_a.my_each { |var| return true if args.match(var) }
-    when Class
-      to_a.my_each { |var| return true if var.class.superclass == args || var.instance_of?(args) }
-    else
-      unless block_given?
-        to_a.my_each { |var| return true if var == true }
+    unless block_given?
+      if args.instance_of?(Regexp)
+        to_a.my_each { |var| return true if args.match(var) }
         return false
+      else
+        to_a.my_each { |var| return true if my_instance_of(args, var) }
       end
 
-      to_a.my_each { |var| return true if yield var }
+      to_a.my_each { |var| return true if var == true }
+      return false
     end
+    to_a.my_each { |var| return true if yield var }
     false
   end
 
   # my_none? Method
   def my_none?(args = nil)
-    case args
-    when Regexp
-      to_a.my_each do |var|
-        my_regexp(false, var)
-      end
-    when Class
-      to_a.my_each { |var| return false if var.class.superclass == args || var.instance_of?(args) }
-    else
-      unless block_given?
-        to_a.my_each { |var| return false if var }
+    unless block_given?
+      if args.instance_of?(Regexp)
+        to_a.my_each { |var| return false if args.match(var) }
         return true
+      else
+        to_a.my_each { |var| return false if my_instance_of(args, var) }
       end
-
-      my_each { |var| return false if yield var }
+      to_a.my_each { |var| return false if var }
+      return true
     end
+    my_each { |var| return false if yield var }
     true
   end
 
@@ -116,8 +109,9 @@ module Enumerable
     mp_new
   end
 
-  def my_regexp(xav, var)
-    return xav if args.match(var)
+  def my_instance_of(args, var)
+    return true if var.instance_of?(var) || var.class.superclass == args
+
+    false
   end
-  p 'hello world'
 end

--- a/main.rb
+++ b/main.rb
@@ -1,13 +1,23 @@
 module Enumerable
   def my_each
-    size.times do |i|
+    to_a.size.times do |i|
       yield self[i]
     end
+    self
   end
 
   def my_each_with_index
-    size.times do |i|
+    to_a.size.times do |i|
       yield self[i], i
     end
+    self
+  end
+
+  def my_select
+    arr = []
+    to_a.size.times do |i|
+      arr.push(self[i]) if yield self[i]
+    end
+    arr
   end
 end

--- a/main.rb
+++ b/main.rb
@@ -1,6 +1,3 @@
-# rubocop:disable Metrics/CyclomaticComplexity
-# rubocop:disable Metrics/PerceivedComplexity
-
 module Enumerable
   # my_each method
   def my_each
@@ -45,6 +42,7 @@ module Enumerable
     true
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def my_inject(arg1 = nil, arg2 = nil)
     if arg1.is_a?(Symbol) && !arg2
       base = to_a[0]
@@ -61,8 +59,9 @@ module Enumerable
     elsif !block_given? && !arg1
       raise LocalJumpError
     else
-      return 'Input Error'
+      raise LocalJumpError, 'No block given'
     end
     base
   end
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/main.rb
+++ b/main.rb
@@ -65,4 +65,10 @@ module Enumerable
     end
     counter
   end
+
+  def my_map
+    mp_new=[]
+    my_each { |var| mp_new.push(yield(var))}
+    mp_new
+  end
 end

--- a/main.rb
+++ b/main.rb
@@ -23,4 +23,17 @@ module Enumerable
     end
     arr
   end
+
+  # my_all? method
+  def my_all?
+    my_each do |var|
+      false unless yield var
+    end
+    true
+  end
 end
+
+
+words = %w[bacon orang apple]
+
+puts [].my_all? {|str| str.size == 5}

--- a/main.rb
+++ b/main.rb
@@ -33,9 +33,9 @@ module Enumerable
   end
 
   # my_all? method
-  def my_all?(args = nil)
+  def my_all?(args = nil) 
     unless block_given?
-      if args.instance_of?(Regexp)
+      if args.instance_of?(Regexp) 
         to_a.my_each { |var| return false unless args.match(var) }
         return true
       else
@@ -110,7 +110,7 @@ module Enumerable
   end
 
   def my_instance_of(args, var)
-    return true if var.instance_of?(var) || var.class.superclass == args
+    return true if var.instance_of?(args) || var.class.superclass == args
 
     false
   end

--- a/main.rb
+++ b/main.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ModuleLength
 module Enumerable
   # my_each method
   def my_each
@@ -32,9 +33,6 @@ module Enumerable
     arr
   end
 
-  
-
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def my_inject(arg1 = nil, arg2 = nil)
     if arg1.is_a?(Symbol) && !arg2
       base = to_a[0]
@@ -56,9 +54,9 @@ module Enumerable
     base
   end
 
-  def my_all?(args = nil) 
+  def my_all?(args = nil)
     unless block_given?
-      if args.instance_of?(Regexp) 
+      if args.instance_of?(Regexp)
         to_a.my_each { |var| return false unless args.match(var) }
         return true
       else
@@ -137,5 +135,5 @@ module Enumerable
 
     false
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end
+# rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity,  Metrics/ModuleLength

--- a/main.rb
+++ b/main.rb
@@ -1,3 +1,7 @@
+# rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/PerceivedComplexity
+# rubocop:disable Metrics/MethodLength
+
 module Enumerable
   # my_each method
   def my_each
@@ -43,20 +47,18 @@ module Enumerable
   end
 
   def my_initemect(*arg)
-
     var = var.is_a?(Range) ? var.to_a : self
 
     base = arg[0].is_a?(Integer) ? arg[0] : 0
     operator = arg[0].is_a?(Symbol) ? arg[0] : arg[1]
-        p operator
-        p base
-    my_each {|var| base = base.send operator, var}
+    p operator
+    p base
+    my_each { |var| base = base.send operator, var }
 
     base
   end
 
   def my_inject(arg1 = nil, arg2 = nil)
-
     if arg1.is_a?(Symbol) && !arg2
       base = to_a[0]
       1.upto(to_a.length - 1) { |item| base = base.send(arg1, to_a[item]) }
@@ -79,8 +81,4 @@ module Enumerable
     end
     base
   end
-
 end
-
-arr = [1,2,3]
-p arr.my_inject(100)

--- a/main.rb
+++ b/main.rb
@@ -1,1 +1,44 @@
-puts 'This is template of Ruby for projects in Microverse'
+module Enumerable
+  # my_each method
+  def my_each
+    return to_enum(:my_each) unless block_given?
+
+    to_a.size.times do |i|
+      yield to_a[i]
+    end
+    self
+  end
+
+  # my_each_with_index
+  def my_each_with_index
+    return to_enum(:my_each_with_index) unless block_given?
+
+    to_a.size.times do |i|
+      yield to_a[i], i
+    end
+    self
+  end
+
+  # my_select method
+  def my_select
+    return to_enum(:my_select) unless block_given?
+
+    arr = []
+    to_a.size.times do |i|
+      arr.push(to_a[i]) if yield to_a[i]
+    end
+    return arr.to_h if is_a? Hash
+
+    arr
+  end
+
+  # my_all? method
+  def my_all?
+    return true unless block_given?
+
+    to_a.size.times do |i|
+      return false unless yield to_a[i]
+    end
+    true
+  end
+end

--- a/main.rb
+++ b/main.rb
@@ -1,6 +1,5 @@
 # rubocop:disable Metrics/CyclomaticComplexity
 # rubocop:disable Metrics/PerceivedComplexity
-# rubocop:disable Metrics/MethodLength
 
 module Enumerable
   # my_each method
@@ -50,9 +49,6 @@ module Enumerable
     if arg1.is_a?(Symbol) && !arg2
       base = to_a[0]
       1.upto(to_a.length - 1) { |item| base = base.send(arg1, to_a[item]) }
-    elsif arg1.is_a?(Integer) && !arg2
-      base = arg1
-      1.upto(to_a.length - 1) { |item| base = base.send(:+, to_a[item]) }
     elsif !arg1.is_a?(Symbol) && arg2.is_a?(Symbol)
       base = arg1
       0.upto(to_a.length - 1) { |item| base = base.send(arg2, to_a[item]) }

--- a/main.rb
+++ b/main.rb
@@ -33,7 +33,17 @@ module Enumerable
   end
 
   # my_all? method
-  def my_all?
+  def my_all? (args=nil)
+    case args
+    when Regexp
+      to_a.my_each do |var|
+        return false unless args.match(var)
+      end
+    when Class
+      to_a.my_each do |var|
+        return false unless var.instance_of?(args)
+      end
+    else  
     return true unless block_given?
 
     to_a.size.times do |i|
@@ -42,33 +52,73 @@ module Enumerable
     true
   end
 
-  def my_any?
-    return true unless block_given?    
-    my_each do |var|
-     return true if yield var
+  # my_any? Method
+  def my_any?(args = nil)
+    case args
+    when Regexp
+      to_a.my_each do |var|
+        return true if args.match(var)
+      end
+    when Class
+      to_a.my_each do |var|
+        return true if var.instance_of?(args)
+      end
+    else
+      return true unless block_given?
+
+      to_a.my_each do |var|
+        return true if yield var
+      end
     end
     false
   end
 
-  def my_none?
-    return false unless block_given?  
+  # my_none? Method
+  def my_none?(args=nil)
+    case args
+    when Regexp
+      to_a.my_each do |var|
+        return false if args.match(var)
+      end
+    when Class
+      to_a.my_each do |var|
+        return false if var.instance_of?(args)
+      end
+    else  
+    return false unless block_given?
+
     my_each do |var|
-     return false if yield var
+      return false if yield var
     end
     true
   end
 
-  def my_count
+  # my_count Method
+  def my_count (num=nil)
+    return to_a.size unless block_given?
     counter=0
+    if num
+      my_each do 
+        |var| 
+        if var == num
+          counter+=1
+        end
+      end
+
+    else
     my_each do |var|
       counter+=1 if yield var
     end
+  end
     counter
   end
 
+  # my_map Method
   def my_map
+    return to_enum(:my_map) unless block_given?
     mp_new=[]
     my_each { |var| mp_new.push(yield(var))}
     mp_new
   end
+
 end

--- a/main.rb
+++ b/main.rb
@@ -57,4 +57,12 @@ module Enumerable
     end
     true
   end
+
+  def my_count
+    counter=0
+    my_each do |var|
+      counter+=1 if yield var
+    end
+    counter
+  end
 end

--- a/main.rb
+++ b/main.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ModuleLength
+# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ModuleLength, Style/ClassEqualityComparison
 module Enumerable
   # my_each method
   def my_each
@@ -59,7 +59,7 @@ module Enumerable
       if args.instance_of?(Regexp)
         to_a.my_each { |var| return false unless args.match(var) }
         return true
-      else
+      elsif args
         to_a.my_each { |var| return false unless my_instance_of(args, var) }
       end
       to_a.my_each { |var| return false unless var }
@@ -76,7 +76,7 @@ module Enumerable
       if args.instance_of?(Regexp)
         to_a.my_each { |var| return true if args.match(var) }
         return false
-      else
+      elsif args
         to_a.my_each { |var| return true if my_instance_of(args, var) }
       end
 
@@ -93,7 +93,7 @@ module Enumerable
       if args.instance_of?(Regexp)
         to_a.my_each { |var| return false if args.match(var) }
         return true
-      else
+      elsif args
         to_a.my_each { |var| return false if my_instance_of(args, var) }
       end
       to_a.my_each { |var| return false if var }
@@ -131,9 +131,43 @@ module Enumerable
   end
 
   def my_instance_of(args, var)
-    return true if var.instance_of?(args) || var.class.superclass == args
+    return true if var.class == args || var.class.superclass == args
 
     false
   end
 end
-# rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity,  Metrics/ModuleLength
+p 'all example' # ALL
+# rubocop:disable Lint/AmbiguousBlockAssociation
+p %w[anta bear cata].my_all? { |word| word.length >= 3 } #=> true
+p %w[ant bear cat].my_all? { |word| word.length >= 4 } #=> false
+p %w[cat cat cat].my_all?(/b/) #=> false
+p [1, 2i, 5].my_all?(Numeric) #=> true
+p [nil, true, 99].my_all? #=> false
+p [].my_all? #=> true
+p 'any examples' # ANY
+
+p %w[ant bear cat].my_any? { |word| word.length >= 3 } #=> true
+p %w[ant bear cat].my_any? { |word| word.length >= 4 } #=> true
+p %w[ant bear cat].my_any?(/d/) #=> false
+p [nil, true, 99].my_any?(Integer) #=> true
+p [nil, true, 99].my_any? #=> true
+p [].my_any? #=> false
+p 'none examples' # NONE
+p %w[ant bear cat].my_none? { |word| word.length == 5 } #=> true
+p %w[ant bear cat].my_none? { |word| word.length >= 4 } #=> false
+p %w[ant bear cat].my_none?(/d/) #=> true
+p [1, 3.14, 42].my_none?(Float) #=> false
+p [].my_none? #=> true
+p [nil].my_none? #=> true
+p [nil, false].my_none? #=> true
+p [nil, false, true].my_none? #=> false
+p 'count examples' # Count
+ary = [1, 2, 4, 2]
+p ary.count(&:even?) #=> 3
+p ary.count #=>4
+p ary.count(2) #=>2
+p 'map examples' # MAP
+p [1, 2, 3, 4].my_map { |i| i * i } #=> [1, 4, 9, 16]
+p [1, 2, 3, 4].my_map { 'cat' } #=> ["cat", "cat", "cat", "cat"]
+
+# rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity,  Metrics/ModuleLength, Style/ClassEqualityComparison, Lint/AmbiguousBlockAssociation

--- a/main.rb
+++ b/main.rb
@@ -41,13 +41,20 @@ module Enumerable
       end
     when Class
       to_a.my_each do |var|
-        return false unless var.instance_of?(args)
+        return false unless var.class.superclass == args || var.class == args
       end
     else  
-    return true unless block_given?
+    unless block_given?
+      to_a.my_each do |var|
+        return false unless var
+      else return true
+      end
+      
+    end  
 
     to_a.size.times do |i|
       return false unless yield to_a[i]
+    end
     end
     true
   end
@@ -82,7 +89,7 @@ module Enumerable
       end
     when Class
       to_a.my_each do |var|
-        return false if var.instance_of?(args)
+        return false if var.class==args || var.class.superclass==args
       end
     else  
     return false unless block_given?
@@ -90,6 +97,7 @@ module Enumerable
     my_each do |var|
       return false if yield var
     end
+  end
     true
   end
 
@@ -121,4 +129,11 @@ module Enumerable
     mp_new
   end
 
+
+p "all example"
+p %w[ant bear cat].my_all? { |word| word.length >= 3 } #=> true
+p %w[ant bear cat].my_all? { |word| word.length >= 4 } #=> false
+p %w[ant bear cat].my_all?(/a/)                        #=> false
+p [1, 2, 3].my_all?(Numeric)                       #=> true
+p [nil, true, 99].my_all?                              #=> false
 end

--- a/main.rb
+++ b/main.rb
@@ -41,4 +41,38 @@ module Enumerable
     end
     true
   end
+
+  def my_inject(*arg)
+
+    if arg.empty?
+      sum = arg[0]
+      operator = :+
+    elsif arg[0].is_a? Symbol
+      operator = arg[0]
+      sum = 0
+    elsif arg[0].is_a? Integer && arg.size > 1
+      sum = arg[0]
+      operator arg[1]
+    elsif arg[0].is_a? Integer
+      sum = 0
+      operator = :+
+    end
+    
+    #if block_given? sum = ; puts var 
+      proc = Proc.new { |num| sum = sum.send operator, num }      
+    #else
+    #  puts "No hay yield"
+    #end
+
+    my_each {|var| proc.call(var) unless block_given?}
+
+    sum
+  end
 end
+
+arr = [1,2,3,4,5,6,]
+p arr.my_inject { |sum, n| sum + n }
+
+
+#p 1.send(:method)
+#p 4.send(:+,5)


### PR DESCRIPTION
Project 2: Enumerable Methods

You learned about the Enumerable module that gets mixed into the Array and Hash classes (among others) and provides you with lots of handy iterator methods. To prove that there's no magic to it, you're going to rebuild those methods.
Assignment 2

    Create a script file to house your methods and run it in IRB to test them later.
    Add your new methods onto the existing Enumerable module. Ruby makes this easy for you because any class or module can be added to without trouble ... just do something like:

  module Enumerable
    def my_each
      # your code here
    end
  end

    Create #my_each, a method that is identical to #each but (obviously) does not use #each. You'll need to remember the yield statement. Make sure it returns the same thing as #each as well.
    Create #my_each_with_index in the same way.
    Create #my_select in the same way, though you may use #my_each in your definition (but not #each).
    Create #my_all? (continue as above)
    Create #my_any?
    Create #my_none?
    Create #my_count
    Create #my_map
    Create #my_inject
    Test your #my_inject by creating a method called #multiply_els which multiplies all the elements of the array together by using #my_inject, e.g. multiply_els([2,4,5]) #=> 40
    Modify your #my_map method to take a proc instead.
    Modify your #my_map method to take either a proc or a block. It won't be necessary to apply both a proc and a block in the same #my_map call since you could get the same effect by chaining together one #my_map call with the block and one with the proc. This approach is also clearer, since the user doesn't have to remember whether the proc or block will be run first. So if both a proc and a block are given, only execute the proc.
